### PR TITLE
Fix duplication of sections across cards

### DIFF
--- a/alert/teams.go
+++ b/alert/teams.go
@@ -72,6 +72,7 @@ func (t *Teams) SendCard() (*http.Response, error) {
 func (c *TeamsMessageCard) CreateCard(p PrometheusAlertMessage) {
 	c.Type = messageType
 	c.Context = context
+	c.Sections = []TeamsMessageCardSection{}
 	switch p.Status {
 	case "resolved":
 		c.ThemeColor = colorResolved


### PR DESCRIPTION
Currently each event gets added as a section to a card so old alerts
are coming through again and again on new cards.

This bug can be replicated by taking the example test json and running
it back to back a few times. The first card will have 1 section, the
second two sections (1 duplicate), the third 3 sections (2 duplicates),
and so on.

Closes:#17