### PR TITLE
Ensure summary is defined

### DIFF
--- a/default-message-card.tmpl
+++ b/default-message-card.tmpl
@@ -8,12 +8,20 @@
                     {{- else if eq .CommonLabels.severity "warning" -}}FFA500
                     {{- else -}}808080{{- end -}}
                  {{- else -}}808080{{- end -}}",
-  "summary": "{{ .CommonAnnotations.summary }}",
+  "summary": "{{- if eq .CommonAnnotations.summary "" -}}
+                  {{- if eq .CommonAnnotations.message "" -}}
+                    {{- .CommonLabels.alertname -}}
+                  {{- else -}}
+                    {{- .CommonAnnotations.message -}}
+                  {{- end -}}
+              {{- else -}}
+                  {{- .CommonAnnotations.summary -}}
+              {{- end -}}",
   "title": "Prometheus Alert ({{ .Status }})",
   "sections": [ {{$externalUrl := .ExternalURL}}
   {{- range $index, $alert := .Alerts }}{{- if $index }},{{- end }}
     {
-      "activityTitle": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})", 
+      "activityTitle": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})",
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {

--- a/examples/templates/card-with-action.tmpl
+++ b/examples/templates/card-with-action.tmpl
@@ -8,12 +8,20 @@
                     {{- else if eq .CommonLabels.severity "warning" -}}FFA500
                     {{- else -}}808080{{- end -}}
                  {{- else -}}808080{{- end -}}",
-  "summary": "{{ .CommonAnnotations.summary }}",
+  "summary": "{{- if eq .CommonAnnotations.summary "" -}}
+                  {{- if eq .CommonAnnotations.message "" -}}
+                    {{- .CommonLabels.alertname -}}
+                  {{- else -}}
+                    {{- .CommonAnnotations.message -}}
+                  {{- end -}}
+              {{- else -}}
+                  {{- .CommonAnnotations.summary -}}
+              {{- end -}}",
   "title": "Prometheus Alert ({{ .Status }})",
   "sections": [ {{$externalUrl := .ExternalURL}}
   {{- range $index, $alert := .Alerts }}{{- if $index }},{{- end }}
     {
-      "activityTitle": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})", 
+      "activityTitle": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})",
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {


### PR DESCRIPTION
Microsoft returns an error code when summary isn't defined.

This PR ensures that summary is defaulted to either message or alertname, in that order.

I generally add summary, but a lot of the default rules from the Prometheus Operator doesn't have summary.

Error response from MS API:
```
time="2019-04-04T21:41:15Z" level=info msg="Microsoft Teams response text: Summary or Text is required."
time="2019-04-04T21:41:15Z" level=error msg="Failed sending to the Teams Channel. Teams http response: 400 Bad Request"
```