### PR TITLE
Ensure summary is defined

### DIFF
--- a/alert/teams_test.go
+++ b/alert/teams_test.go
@@ -112,6 +112,18 @@ func TestCreateCardsTemplateWithoutSections(t *testing.T) {
 	}
 }
 
+func TestTemplateWithoutSummaryOrText(t *testing.T) {
+	testdata := "testdata/prom_post_request_without_common_summary.json"
+	cards, _ := createCardsFromPrometheusTestAlert(testdata, "../default-message-card.tmpl", t)
+	jsonparser.ArrayEach([]byte(cards), func(card []byte, dataType jsonparser.ValueType, offset int, err error) {
+		summary := jsonparserGetString(card, "summary")
+		text := jsonparserGetString(card, "text")
+		if (summary == "") && (text == "") {
+			t.Fatalf("Microsoft Teams message requires Summary or Text")
+		}
+	})
+}
+
 func TestLargePostRequest(t *testing.T) {
 	// test larged sized message
 	testdata := "testdata/large_prom_post_request.json"

--- a/alert/testdata/prom_post_request_without_common_summary.json
+++ b/alert/testdata/prom_post_request_without_common_summary.json
@@ -1,0 +1,33 @@
+{
+  "version": "4",
+  "groupKey": "{}:{alertname=\"high_memory_load\"}",
+  "status": "firing",
+  "receiver": "teams_proxy",
+  "groupLabels": {
+      "alertname": "high_memory_load"
+  },
+  "commonLabels": {
+      "alertname": "high_memory_load",
+      "monitor": "master",
+      "severity": "warning"
+  },
+  "commonAnnotations": {},
+  "externalURL": "http://docker.for.mac.host.internal:9093",
+  "alerts": [
+      {
+          "labels": {
+              "alertname": "high_memory_load",
+              "instance": "instance-with-hyphen_and_underscore",
+              "job": "docker_nodes",
+              "monitor": "master",
+              "severity": "warning"
+          },
+          "annotations": {
+              "description": "10.80.40.11 reported high memory usage with 23.28%.",
+              "summary": "Server High Memory usage"
+          },
+          "startsAt": "2018-03-07T06:33:21.873077559-05:00",
+          "endsAt": "0001-01-01T00:00:00Z"
+      }
+  ]
+}

--- a/chart/prometheus-msteams/card.tmpl
+++ b/chart/prometheus-msteams/card.tmpl
@@ -8,12 +8,20 @@
                     {{- else if eq .CommonLabels.severity "warning" -}}FFA500
                     {{- else -}}808080{{- end -}}
                  {{- else -}}808080{{- end -}}",
-  "summary": "{{ .CommonAnnotations.summary }}",
+  "summary": "{{- if eq .CommonAnnotations.summary "" -}}
+                  {{- if eq .CommonAnnotations.message "" -}}
+                    {{- .CommonLabels.alertname -}}
+                  {{- else -}}
+                    {{- .CommonAnnotations.message -}}
+                  {{- end -}}
+              {{- else -}}
+                  {{- .CommonAnnotations.summary -}}
+              {{- end -}}",
   "title": "Prometheus Alert ({{ .Status }})",
   "sections": [ {{$externalUrl := .ExternalURL}}
   {{- range $index, $alert := .Alerts }}{{- if $index }},{{- end }}
     {
-      "activityTitle": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})", 
+      "activityTitle": "[{{ $alert.Annotations.description }}]({{ $externalUrl }})",
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {


### PR DESCRIPTION
@bjornryden as you may have seen, I have merged your PR #45 and released it in v1.1.1.

I just recognised that you haven't updated the template in the helm chart. Apart from that I thought it would make sense to add a unit test in order to test further changes on the message card template.

Then I stumbled through your if else statements in the template file and wondered what if neither `.CommonAnnotations.summary` nor `.CommonAnnotations.message` nor `.CommonLabels.alertname` are present? Shouldn't we add a default hard-coded value, something like `Prometheus Alert`?