### PR TITLE
fix concatinating key-val pairs if the val starts with [

### DIFF
--- a/alert/teams.go
+++ b/alert/teams.go
@@ -57,7 +57,7 @@ func compact(data []byte) string {
 }
 
 func concatKeyValue(key string, val string) string {
-	if strings.HasPrefix(val, "[") {
+	if strings.HasPrefix(val, "[{") {
 		return "\"" + key + "\":" + val
 	}
 	return "\"" + key + "\":\"" + val + "\""

--- a/alert/teams.go
+++ b/alert/teams.go
@@ -219,7 +219,7 @@ func SendCard(webhook string, card string, maxIdleConns int, idleConnTimeout tim
 
 	res, err := c.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed sending to webhook url %s. Got the error: %v", webhook, err)
+		return res, fmt.Errorf("Failed sending to webhook url %s. Got the error: %v", webhook, err)
 	}
 
 	rb, err := ioutil.ReadAll(res.Body)
@@ -229,9 +229,9 @@ func SendCard(webhook string, card string, maxIdleConns int, idleConnTimeout tim
 	log.Infof("Microsoft Teams response text: %s", string(rb))
 	if res.StatusCode != http.StatusOK {
 		if err != nil {
-			return nil, fmt.Errorf("Failed reading Teams http response: %v", err)
+			return res, fmt.Errorf("Failed reading Teams http response: %v", err)
 		}
-		return nil, fmt.Errorf("Failed sending to the Teams Channel. Teams http response: %s",
+		return res, fmt.Errorf("Failed sending to the Teams Channel. Teams http response: %s",
 			res.Status)
 	}
 	if err := res.Body.Close(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/stretchr/testify v1.2.2
 	gopkg.in/yaml.v2 v2.2.2
 )


### PR DESCRIPTION
Fixes #54.

This might not be an indication that it is an array. Values starting with `[{` should be rather an indication for an array. 