### PR TITLE
JSON logs

### DIFF
--- a/alert/prom_handler.go
+++ b/alert/prom_handler.go
@@ -88,12 +88,13 @@ func (promWebhook *PrometheusWebhook) PrometheusAlertManagerHandler(
 		return
 	}
 
-	log.Debugf("Prometheus Alert: %v", String(promAlert))
+	log.WithField("payload", promAlert).Debug("Prometheus alert received")
 	cards, err := CreateCards(promAlert, promWebhook)
 	if err != nil {
 		log.Error(err)
 		return
 	}
+
 	log.Infof("Created a card for Microsoft Teams %s", r.RequestURI)
 	log.Debugf("Teams message cards: %v", cards)
 

--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/stretchr/testify v1.2.2
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/main.go
+++ b/main.go
@@ -21,8 +21,20 @@
 package main
 
 import (
+	"os"
+
 	"github.com/bzon/prometheus-msteams/cmd"
+	log "github.com/sirupsen/logrus"
 )
+
+func init() {
+	// Log as JSON instead of the default ASCII formatter.
+	log.SetFormatter(&log.JSONFormatter{})
+
+	// Output to stdout instead of the default stderr
+	// Can be any io.Writer, see below for File example
+	log.SetOutput(os.Stdout)
+}
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Example output.

```json
{
  "level": "debug",
  "msg": "prometheus alert received",
  "prometheus": {
    "receiver": "teams_proxy",
    "status": "firing",
    "alerts": [
      {
        "status": "",
        "labels": {
          "alertname": "high_memory_load",
          "instance": "10.80.40.11:9100",
          "job": "docker_nodes",
          "monitor": "master",
          "severity": "warning"
        },
        "annotations": {
          "description": "10.80.40.11 reported high memory usage with 23.28%.",
          "summary": "Server High Memory usage"
        },
        "startsAt": "2018-03-07T06:33:21.873077559-05:00",
        "endsAt": "0001-01-01T00:00:00Z",
        "generatorURL": ""
      }
    ],
    "groupLabels": {
      "alertname": "high_memory_load"
    },
    "commonLabels": {
      "alertname": "high_memory_load",
      "monitor": "master",
      "severity": "warning"
    },
    "commonAnnotations": {
      "summary": "Server High Memory usage"
    },
    "externalURL": "http://docker.for.mac.host.internal:9093",
    "version": "4",
    "groupKey": "{}:{alertname=\"high_memory_load\"}"
  },
  "time": "2019-10-03T12:53:34+02:00"
}
```