### PR TITLE
fixing issue 68 "summary or text is required"

### DIFF
--- a/chart/prometheus-msteams/card.tmpl
+++ b/chart/prometheus-msteams/card.tmpl
@@ -10,7 +10,7 @@
                  {{- else -}}808080{{- end -}}",
   "summary": "{{- if eq .CommonAnnotations.summary "" -}}
                   {{- if eq .CommonAnnotations.message "" -}}
-                    {{- .CommonLabels.alertname -}}
+                    {{- .CommonLabels.cluster -}}-cluster
                   {{- else -}}
                     {{- .CommonAnnotations.message -}}
                   {{- end -}}
@@ -25,14 +25,14 @@
       "facts": [
         {{- range $key, $value := $alert.Annotations }}
         {
-          "name": "{{ reReplaceAll "_" "\\\\_" $key }}",
-          "value": "{{ reReplaceAll "_" "\\\\_" $value }}"
+          "name": "{{ reReplaceAll "_" " " $key }}",
+          "value": "{{ reReplaceAll "_" " " $value }}"
         },
         {{- end -}}
         {{$c := counter}}{{ range $key, $value := $alert.Labels }}{{if call $c}},{{ end }}
         {
-          "name": "{{ reReplaceAll "_" "\\\\_" $key }}",
-          "value": "{{ reReplaceAll "_" "\\\\_" $value }}"
+          "name": "{{ reReplaceAll "_" " " $key }}",
+          "value": "{{ reReplaceAll "_" " " $value }}"
         }
         {{- end }}
       ],


### PR DESCRIPTION
Modified the default Microsoft Teams Message card template as:
- Edited the summary section to fill the value to avoid errors when sending it to Microsoft Teams. 
- Edited to replace underscore(_) to blank.