### PR TITLE
Use custom cards with helm chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -6,6 +6,7 @@
 * [Prepare the Deployment configuration](#prepare-the-deployment-configuration)
 * [Deploy to Kubernetes cluster](#deploy-to-kubernetes-cluster)
 * [When using with Prometheus Operator](#when-using-with-prometheus-operator)
+* [Customise messages to MS Teams](#customise-messages-to-MS-Teams)
 * [Helm Configuration](#helm-configuration)
 
 <!-- vim-markdown-toc -->
@@ -47,7 +48,6 @@ container:
 
 See [Helm Configuration](#helm-configuration) for reference.
 
-Optionally you can customise the [Teams Message Card Template](./prometheus-msteams/card.tmpl). See [README](../README.md#customise-messages-to-ms-teams) for more information.
 
 ### Deploy to Kubernetes cluster
 
@@ -58,6 +58,21 @@ helm install --name prometheus-msteams ./prometheus-msteams --namespace monitori
 ### When using with Prometheus Operator
 
 Please see [Prometheus Operator alerting docs](https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/alerting.md).
+
+
+### Customise messages to MS Teams
+
+This application uses a [Default Teams Message Card Template](./prometheus-msteams/card.tmpl) to convert incoming Prometheus alerts to teams message cards. 
+This template can be customised by specifying the value of `customCardTemplate` parameter. 
+Simply create a new file that you want to use as your custom template (for example, `custom-card.tmpl`).
+You can use the `--set-file` flag to set the value from this file:
+
+```bash
+helm install --name prometheus-msteams ./prometheus-msteams --namespace monitoring --set-file customCardTemplate=custom-card.tmpl -f config.yaml
+```
+
+Otherwise you can also set the value by specifying the template data directly via values file.
+
 
 ### Helm Configuration
 
@@ -74,3 +89,7 @@ Please see [Prometheus Operator alerting docs](https://github.com/coreos/prometh
 | container.additionalArgs | additional prometheus-msteams flags to use             | None                                            |
 | resources                | CPU/memory resource requests/limits                    | See [default](./prometheus-msteams/values.yaml) |
 | nodeSelector             | Labels for Node selector                               | {}                                              |
+| customCardTemplate       | Custom message card template for MS teams              | None                                            |
+
+
+

--- a/chart/prometheus-msteams/templates/configMapTemplate.yaml
+++ b/chart/prometheus-msteams/templates/configMapTemplate.yaml
@@ -4,4 +4,9 @@ kind: ConfigMap
 metadata:
  name: prometheus-msteams-card-template
 binaryData:
-  card.tmpl: {{ .Files.Get "card.tmpl" | b64enc }}
+  card.tmpl: |-
+{{- if .Values.customCardTemplate }}
+{{ .Values.customCardTemplate | b64enc | indent 4 }}
+{{- else }}
+{{ .Files.Get "card.tmpl" | b64enc | indent 4 }}
+{{- end }}

--- a/chart/prometheus-msteams/values.yaml
+++ b/chart/prometheus-msteams/values.yaml
@@ -33,3 +33,13 @@ affinity: {}
 # Replace this!
 connectors:
   - alertmanager: https://outlook.office.com/webhook/xxxxx/IncomingWebhook/xxxx/xxxxx
+
+
+## Specify the custom message card template for MS teams
+# customCardTemplate: |
+#   {{ define "teams.card" }}
+#   {
+#     
+#   }
+#   {{ end }}
+


### PR DESCRIPTION
Edited the configMapTemplate.yaml to accept the message card template provided by the user through a value customCardTemplate.