### PR TITLE
Fix deprecated api which is incompatoble with Kubernetes > 1.16

### DIFF
--- a/chart/prometheus-msteams/Chart.yaml
+++ b/chart/prometheus-msteams/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.1.4"
 description: A Helm chart for Kubernetes
 name: prometheus-msteams
-version: 0.3.0
+version: 0.3.1

--- a/chart/prometheus-msteams/templates/deployment.yaml
+++ b/chart/prometheus-msteams/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "app.name" . }}


### PR DESCRIPTION
Hey, we wanna use the cahrt in Kubernetes 1.16 and your deployment still uses the deprecated api version which is to finally be removed. 

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Greetz Flowkap :)